### PR TITLE
Rewrite Node to not use Option

### DIFF
--- a/an-rope/src/internals.rs
+++ b/an-rope/src/internals.rs
@@ -135,8 +135,7 @@ impl Node {
                 // splitting an empty leaf node returns two empty leaf nodes
                 (Node::empty(), Node::empty())
           , Leaf(ref s) if s.len() == 1 =>
-                // TODO: handle this case
-                unimplemented!()
+                (Leaf(s.clone()), Node::empty())
           , Leaf(s) => {
                 // splitting a leaf node with length >= 2 returns two new Leaf
                 // nodes, one with the left half of the string, and one with

--- a/an-rope/src/internals.rs
+++ b/an-rope/src/internals.rs
@@ -162,12 +162,6 @@ impl Node {
     }
 
     #[inline]
-    pub fn concat(&mut self, right: Self) -> &mut Self {
-        *self = Node::new_branch(mem::replace(self, Node::empty()), right);
-        self
-    }
-
-    #[inline]
     pub const fn new_leaf(string: String) -> Self {
         Leaf(string)
     }
@@ -399,6 +393,16 @@ impl ops::Add for Node {
     type Output = Self;
     /// Concatenate two `Node`s, returning a `Branch` node.
     fn add(self, right: Self) -> Self { Node::new_branch(self, right) }
+}
+
+
+impl ops::AddAssign for Node {
+    /// Concatenate two `Node`s
+    fn add_assign(&mut self, right: Self) {
+        use std::mem::replace;
+        *self = Node::new_branch(replace(self, Node::empty()), right)
+     }
+
 }
 
 

--- a/an-rope/src/internals.rs
+++ b/an-rope/src/internals.rs
@@ -91,6 +91,10 @@ impl Node {
         // it. Therefore, the assignment to `self` must be outside the `if let`
         // clause.
         *self = if let Leaf(ref mut s) = *self {
+            assert!( s.len() >= 1
+                   , "Node::split_leaf: String {} had only {} characters and \
+                      thus could not be split at index {}."
+                   , s, s.len(), index);
 
             // if this node is a Leaf, take the String out of it
             // (note that empty strings don't allocate).

--- a/an-rope/src/internals.rs
+++ b/an-rope/src/internals.rs
@@ -335,8 +335,7 @@ impl<'a> Iterator for Leaves<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         match self.0.pop() {
             None => None
-          , Some(leaf @ &Leaf(_)) => if leaf.len() == 0 { None }
-                                     else { Some(leaf) }
+          , Some(leaf @ &Leaf(_)) => Some(leaf)
           , Some(&Branch(BranchNode { ref left, ref right, .. })) => {
                 self.0.push(left);
                 self.0.push(right);
@@ -354,8 +353,7 @@ impl Iterator for IntoLeaves {
     fn next(&mut self) -> Option<Self::Item> {
         match self.0.pop() {
             None => None
-          , Some(leaf @ Leaf(_)) => if leaf.len() == 0 { None }
-                                    else { Some(leaf) }
+          , Some(leaf @ Leaf(_)) => Some(leaf)
           , Some(Branch(BranchNode { box left, box right, .. })) => {
                 self.0.push(right);
                 self.0.push(left);

--- a/an-rope/src/internals.rs
+++ b/an-rope/src/internals.rs
@@ -55,20 +55,38 @@ impl BranchNode {
     fn split(self, index: usize) -> (Node, Node) {
         let weight = (&self).weight;
         if index < weight {
-            // split the left node
+            // if the index to split on is less than this node's weight,
+            // we split this node's left child.
             let (left, left_right) = self.left.split(index);
+            // the left side of the split left child will become the left side
+            // of the split pair.
+
             let right = if (&left_right).len() == 0 {
+                // if the right side of the split is empty, then the right
+                // side of the returned pair is just this node's right child
                 *self.right
             } else {
+                // otherwise, the right side of the returned pair is a branch
+                // containing the right side of the split node on the left,
+                // and this node's right child on the right
                 Node::new_branch(left_right, *self.right)
             };
             (left, right)
         } else {
-            // split the right node;
+            // if the index is not less than this node's weight, we split the
+            // right child
             let (right_left, right) = self.right.split(index - weight);
+            // the right side of the split right child will become the right
+            // side of the split
+
             let left = if (&right_left).len() == 0 {
+                // if the left side of the split right child is empty, then the
+                // left side of the returned pair is just this node's left child
                 *self.left
             } else {
+                // otherwise, the left side of the returned pair is a branch
+                // containing the left side of the split node on the right,
+                // and this node's left child on the left
                 Node::new_branch(*self.left, right_left)
             };
             (left, right)

--- a/an-rope/src/internals.rs
+++ b/an-rope/src/internals.rs
@@ -162,8 +162,9 @@ impl Node {
     }
 
     #[inline]
-    pub fn concat(&mut self, right: Self) {
-        *self = Node::new_branch(mem::replace(self, Node::empty()), right)
+    pub fn concat(&mut self, right: Self) -> &mut Self {
+        *self = Node::new_branch(mem::replace(self, Node::empty()), right);
+        self
     }
 
     #[inline]

--- a/an-rope/src/internals.rs
+++ b/an-rope/src/internals.rs
@@ -374,3 +374,20 @@ impl ops::Add for Node {
     /// Concatenate two `Node`s, returning a `Branch` node.
     fn add(self, right: Self) -> Self { Node::new_branch(self, right) }
 }
+
+
+impl ops::Index<usize> for Node {
+    type Output = str;
+
+    fn index(&self, i: usize) -> &str {
+        let len = self.len();
+        assert!( i < len
+               , "Node::index: index {} out of bounds (length {})", i, len);
+        match *self {
+            Leaf(ref vec) => { &vec[i..i+1] }
+          , Branch(BranchNode { box ref right, .. }) if len < i =>
+                &right[i - len]
+          , Branch(BranchNode { box ref left, .. }) => &left[i]
+        }
+    }
+}

--- a/an-rope/src/internals.rs
+++ b/an-rope/src/internals.rs
@@ -337,8 +337,8 @@ impl<'a> Iterator for Leaves<'a> {
             None => None
           , Some(leaf @ &Leaf(_)) => Some(leaf)
           , Some(&Branch(BranchNode { ref left, ref right, .. })) => {
-                self.0.push(left);
                 self.0.push(right);
+                self.0.push(left);
                 self.next()
             }
         }

--- a/an-rope/src/internals.rs
+++ b/an-rope/src/internals.rs
@@ -165,8 +165,7 @@ impl Node {
     #[inline]
     fn subtree_weight (&self) -> usize {
         match self { &Leaf(ref s) => s.len()
-                   , &Branch(BranchNode { ref left, .. }) =>
-                        left.subtree_weight()
+                   , &Branch(BranchNode { ref left, .. }) => left.len()
                     }
     }
 

--- a/an-rope/src/internals.rs
+++ b/an-rope/src/internals.rs
@@ -78,7 +78,7 @@ impl BranchNode {
             // replacing *self with a new BranchNode will update the
             // node's weight automagically
             *self = BranchNode::new(self.take_left(), right);
-            self.left.as_mut()
+            self.right.as_mut()
         }
     }
 

--- a/an-rope/src/internals.rs
+++ b/an-rope/src/internals.rs
@@ -115,7 +115,8 @@ impl Node {
             if let &mut Branch(ref mut node) = self {
                 node.split(index)
             } else {
-                unreachable!()
+                unreachable!("A node that was neither a leaf nor a branch \
+                              happened?")
             }
         }
     }

--- a/an-rope/src/internals.rs
+++ b/an-rope/src/internals.rs
@@ -52,16 +52,6 @@ impl BranchNode {
                    }
     }
 
-    #[inline]
-    fn take_left(&mut self) -> Node {
-        mem::replace(self.left.as_mut(), Node::empty())
-    }
-
-    #[inline]
-    fn take_right(&mut self) -> Node {
-        mem::replace(self.right.as_mut(), Node::empty())
-    }
-
     fn split(self, index: usize) -> (Node, Node) {
         let weight = (&self).weight;
         if index < weight {

--- a/an-rope/src/lib.rs
+++ b/an-rope/src/lib.rs
@@ -222,11 +222,13 @@ impl Rope {
                 let root = mem::replace(&mut self.root, Node::empty());
                 // split the rope at the given index
                 let (left, right) = root.split(index);
+
+                // construct the new root node with `Rope` inserted
+                self.root = left;
                 // concatenate the left side of the rope to insert
-                let left = Node::new_branch(left, rope.root);
-                // concatenate the right side of the split to the
-                // new node and put the new node in the root position
-                self.root = Node::new_branch(left, right);
+                // concatenate the right side of the split to the new node
+                self.root.concat(rope.root)
+                         .concat(right);
             }
             // rebalance the new rope
             self.rebalance();
@@ -358,6 +360,7 @@ impl Rope {
     /// an_rope.append(Rope::from(String::from("efgh")));
     /// assert_eq!(an_rope, Rope::from(String::from("abcdefgh")) );
     /// ```
+
     pub fn append(&mut self, other: Rope) {
         if other.len() > 0 {
             self.root.concat(other.root);
@@ -425,6 +428,21 @@ impl Rope {
     /// let another_rope = an_rope.with_prepend(Rope::from("abcd"));
     /// assert_eq!(&an_rope, "efgh");
     /// assert_eq!(&another_rope, "abcdefgh");
+    /// ```
+    /// ```
+    /// use an_rope::Rope;
+    /// let an_rope = Rope::from("");
+    /// let another_rope = an_rope.with_prepend(Rope::from("abcd"));
+    /// assert_eq!(&an_rope, "");
+    /// assert_eq!(&another_rope, "abcd");
+    /// ```
+    /// ```
+    /// use an_rope::Rope;
+    /// let an_rope = Rope::from("abcd");
+    /// let another_rope = an_rope.with_prepend(Rope::from(""));
+    /// assert_eq!(&an_rope, "abcd");
+    /// assert_eq!(&another_rope, &an_rope);
+    /// assert_eq!(&another_rope, "abcd");
     /// ```
     pub fn with_prepend(&self, other: Rope) -> Rope {
         if other.len() == 0 {

--- a/an-rope/src/lib.rs
+++ b/an-rope/src/lib.rs
@@ -358,7 +358,6 @@ impl Rope {
     /// an_rope.append(Rope::from(String::from("efgh")));
     /// assert_eq!(an_rope, Rope::from(String::from("abcdefgh")) );
     /// ```
-
     pub fn append(&mut self, other: Rope) {
         if other.len() > 0 {
             self.root.concat(other.root);

--- a/an-rope/src/lib.rs
+++ b/an-rope/src/lib.rs
@@ -21,7 +21,6 @@ use std::mem;
 #[cfg(test)]
 mod test;
 
-use self::internals::Node::*;
 use self::internals::Node;
 
 /// A Rope

--- a/an-rope/src/lib.rs
+++ b/an-rope/src/lib.rs
@@ -71,7 +71,7 @@ impl Rope {
     /// # Examples
     /// ```
     /// use an_rope::Rope;
-    /// let mut an_rope = Rope::<u8>::empty();
+    /// let mut an_rope = Rope::new();
     /// assert_eq!(an_rope.len(), 0);
     /// ```
     pub fn new() -> Rope {
@@ -83,7 +83,7 @@ impl Rope {
     /// # Examples
     /// ```
     /// use an_rope::Rope;
-    /// let mut an_empty_rope = Rope::empty();
+    /// let mut an_empty_rope = Rope::new();
     /// assert_eq!(an_empty_rope.len(), 0);
     /// ```
     /// ```
@@ -353,20 +353,20 @@ impl Rope {
     /// ```
     /// use an_rope::Rope;
     /// let mut an_rope = Rope::from(String::from("abcd"));
-    /// an_rope.append(Rope::from(String::from("efgh")))
-    /// assert_eq!(an_rope, Rope::from(String::from("abcdefgh")));
+    /// an_rope.append(Rope::from(String::from("efgh")));
+    /// assert_eq!(an_rope, Rope::from(String::from("abcdefgh")) );
     /// ```
     /// ```
     /// use an_rope::Rope;
     /// let mut an_rope = Rope::from("");
     /// an_rope.append(Rope::from("abcd"));
-    /// assert_eq!(an_rope, "abcd");
+    /// assert_eq!(&an_rope, "abcd");
     /// ```
     /// ```
     /// use an_rope::Rope;
     /// let mut an_rope = Rope::from("abcd");
     /// an_rope.append(Rope::from(""));
-    /// assert_eq!(an_rope, "abcd");
+    /// assert_eq!(&an_rope, "abcd");
     /// ```
     pub fn append(&mut self, other: Rope) {
         if other.len() > 0 {
@@ -386,21 +386,21 @@ impl Rope {
     /// use an_rope::Rope;
     /// let an_rope = Rope::from("abcd");
     /// let another_rope = an_rope.with_append(Rope::from("efgh"));
-    /// assert_eq!(another_rope, "abcdefgh");
-    /// assert_eq!(an_rope, "abcd");
+    /// assert_eq!(&another_rope, "abcdefgh");
+    /// assert_eq!(&an_rope, "abcd");
     /// ```
     /// ```
     /// use an_rope::Rope;
     /// let an_rope = Rope::from("");
     /// let another_rope = an_rope.with_append(Rope::from("abcd"));
-    /// assert_eq!(another_rope, "abcd");
-    /// assert_eq!(an_rope, "");
+    /// assert_eq!(&another_rope, "abcd");
+    /// assert_eq!(&an_rope, "");
     /// ```
     /// ```
     /// use an_rope::Rope;
     /// let an_rope = Rope::from("abcd");
     /// let an_rope = an_rope.with_append(Rope::from(""));
-    /// assert_eq!(an_rope, "abcd");
+    /// assert_eq!(&an_rope, "abcd");
     /// ```
     pub fn with_append(&self, other: Rope) -> Rope {
         if other.len() == 0 {
@@ -425,20 +425,20 @@ impl Rope {
     /// ```
     /// use an_rope::Rope;
     /// let mut an_rope = Rope::from(String::from("efgh"));
-    /// an_rope.prepend(Rope::from(String::from("abcd")))
-    /// assert_eq!(an_rope, "abcdefgh");
+    /// an_rope.prepend(Rope::from(String::from("abcd")));
+    /// assert_eq!(&an_rope, "abcdefgh");
     /// ```
     /// ```
     /// use an_rope::Rope;
     /// let mut an_rope = Rope::from("");
     /// an_rope.prepend(Rope::from("abcd"));
-    /// assert_eq!(an_rope, "abcd");
+    /// assert_eq!(&an_rope, "abcd");
     /// ```
     /// ```
     /// use an_rope::Rope;
     /// let mut an_rope = Rope::from("abcd");
     /// an_rope.prepend(Rope::from(""));
-    /// assert_eq!(an_rope, "abcd");
+    /// assert_eq!(&an_rope, "abcd");
     /// ```
     pub fn prepend(&mut self, other: Rope) {
         if other.len() > 0 {
@@ -458,23 +458,23 @@ impl Rope {
     /// use an_rope::Rope;
     /// let an_rope = Rope::from("efgh");
     /// let another_rope = an_rope.with_prepend(Rope::from("abcd"));
-    /// assert_eq!(an_rope, "efgh");
-    /// assert_eq!(another_rope, "abcdefgh");
+    /// assert_eq!(&an_rope, "efgh");
+    /// assert_eq!(&another_rope, "abcdefgh");
     /// ```
     /// ```
     /// use an_rope::Rope;
     /// let an_rope = Rope::from("");
     /// let another_rope = an_rope.with_prepend(Rope::from("abcd"));
-    /// assert_eq!(an_rope, "");
-    /// assert_eq!(another_rope, "abcd");
+    /// assert_eq!(&an_rope, "");
+    /// assert_eq!(&another_rope, "abcd");
     /// ```
     /// ```
     /// use an_rope::Rope;
     /// let an_rope = Rope::from("abcd");
     /// let another_rope = an_rope.with_prepend(Rope::from(""));
-    /// assert_eq!(an_rope, "abcd");
-    /// assert_eq!(another_rope, an_rope);
-    /// assert_eq!(another_rope, "abcd");
+    /// assert_eq!(&an_rope, "abcd");
+    /// assert_eq!(&another_rope, &an_rope);
+    /// assert_eq!(&another_rope, "abcd");
     /// ```
     pub fn with_prepend(&self, other: Rope) -> Rope {
         if other.len() == 0 {
@@ -679,7 +679,7 @@ impl<'a> ops::Add for &'a Rope {
     /// use an_rope::Rope;
     /// let rope = Rope::from(String::from("ab"));
     /// assert_eq!( &rope + &Rope::from(String::from("cd"))
-    ///           , Rope::from(String::from("abcd")));
+    ///           , Rope::from(String::from("abcd")) );
     /// ```
     #[inline] fn add(self, other: Self) -> Rope { self.with_append((*other).clone()) }
 
@@ -709,7 +709,7 @@ impl ops::Add<String> for Rope {
     /// ```
     /// use an_rope::Rope;
     /// let rope = Rope::from(String::from("ab"));
-    /// assert_eq!( rope + String::from("cd"))
+    /// assert_eq!( rope + String::from("cd")
     ///           , Rope::from(String::from("abcd")));
     /// ```
     #[inline] fn add(self, other: String) -> Rope {
@@ -728,7 +728,7 @@ impl<'a, 'b> ops::Add<&'b str> for &'a Rope {
     /// ```
     /// use an_rope::Rope;
     /// let rope = Rope::from(String::from("ab"));
-    /// assert_eq!( &rope + "cd")
+    /// assert_eq!( &rope + "cd"
     ///           , Rope::from(String::from("abcd")));
     /// ```
     #[inline] fn add(self, other: &'b str) -> Rope {
@@ -747,7 +747,7 @@ impl<'a> ops::Add<&'a str> for Rope {
     /// ```
     /// use an_rope::Rope;
     /// let rope = Rope::from(String::from("ab"));
-    /// assert_eq!( rope + "cd")
+    /// assert_eq!( rope + "cd"
     ///           , Rope::from(String::from("abcd")));
     /// ```
     #[inline] fn add(self, other: &'a str) -> Rope {

--- a/an-rope/src/lib.rs
+++ b/an-rope/src/lib.rs
@@ -364,7 +364,7 @@ impl Rope {
 
     pub fn append(&mut self, other: Rope) {
         if other.len() > 0 {
-            self.root.concat(other.root);
+            self.root += other.root;
             self.rebalance();
         }
     }

--- a/an-rope/src/lib.rs
+++ b/an-rope/src/lib.rs
@@ -86,19 +86,24 @@ impl Rope {
     /// Returns the length of this Rope
     ///
     /// # Examples
+    ///
     /// An empty `Rope` should have length 0.
+    ///
     /// ```
     /// use an_rope::Rope;
     /// let mut an_empty_rope = Rope::new();
     /// assert_eq!(an_empty_rope.len(), 0);
     /// ```
+    ///
     /// ```
     /// use an_rope::Rope;
     /// let mut an_empty_rope = Rope::from(String::from(""));
     /// assert_eq!(an_empty_rope.len(), 0);
     /// ```
+    ///
     /// A `Rope` with text should have length equal to the number of
     /// characters in the `Rope`.
+    ///
     /// ```
     /// use an_rope::Rope;
     /// let mut an_rope = Rope::from(String::from("a string"));
@@ -109,7 +114,7 @@ impl Rope {
     /// Insert `char` into `index` in this `Rope`,
     ///
     /// # Panics
-    /// + If `index` is greater than the length of this `Rope`
+    /// * If `index` is greater than the length of this `Rope`
     ///
     /// # Time Complexity
     /// O(log _n_)
@@ -117,6 +122,7 @@ impl Rope {
     /// # Examples
     ///
     /// Inserting at index 0 prepends `char` to this `Rope`:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("bcd");
     /// an_rope.insert(0, 'a');
@@ -124,13 +130,15 @@ impl Rope {
     /// ```
     ///
     /// Inserting at index `len` prepends `char` to this `Rope`:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("abc");
     /// an_rope.insert(an_rope.len(), 'd');
     /// assert_eq!(an_rope, Rope::from("abcd"));
     /// ```
     ///
-    ///Inserting at an index in the middle inserts `char` at that index:
+    /// Inserting at an index in the middle inserts `char` at that index:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("acd");
     /// an_rope = an_rope.insert(1, 'b');
@@ -151,17 +159,18 @@ impl Rope {
     ///
     ///
     /// # Returns
-    /// + A new `Rope` with `ch` inserted at `index`
+    /// * A new `Rope` with `ch` inserted at `index`
     ///
     /// # Time Complexity
     /// O(log _n_)
     ///
     /// # Panics
-    /// + If `index` is greater than the length of this `Rope`
+    /// * If `index` is greater than the length of this `Rope`
     ///
     /// # Examples
     ///
     /// Inserting at index 0 prepends `rope` to this `Rope`:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("bcd");
     /// an_rope = an_rope.with_insert(0, 'a'));
@@ -169,13 +178,15 @@ impl Rope {
     /// ```
     ///
     /// Inserting at index `len` prepends `char` to this `Rope`:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("abc");
     /// an_rope = an_rope.with_insert(an_rope.len(), 'd');
     /// assert_eq!(an_rope, Rope::from("abcd"));
     /// ```
     ///
-    ///Inserting at an index in the middle inserts `char` at that index:
+    /// Inserting at an index in the middle inserts `char` at that index:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("acd");
     /// an_rope = an_rope.with_insert(1, 'b'));
@@ -197,7 +208,7 @@ impl Rope {
     /// Consumes `rope`.
     ///
     /// # Panics
-    /// + If `index` is greater than the length of this `Rope`
+    /// * If `index` is greater than the length of this `Rope`
     ///
     /// # Time Complexity
     /// O(log _n_)
@@ -205,6 +216,7 @@ impl Rope {
     /// # Examples
     ///
     /// Inserting at index 0 prepends `rope` to this `Rope`:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("cd");
     /// an_rope.insert_rope(0, Rope::from("ab"));
@@ -212,13 +224,15 @@ impl Rope {
     /// ```
     ///
     /// Inserting at index `len` prepends `rope` to this `Rope`:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("ab");
     /// an_rope.insert_rope(an_rope.len(), Rope::from("cd"));
     /// assert_eq!(an_rope, Rope::from("abcd"));
     /// ```
     ///
-    ///Inserting at an index in the middle inserts `rope` at that index:
+    /// Inserting at an index in the middle inserts `rope` at that index:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("ad");
     /// an_rope = an_rope.insert_rope(1, Rope::from("bd"));
@@ -249,18 +263,20 @@ impl Rope {
     ///
     /// Consumes `rope`.
     ///
+    ///
     /// # Returns
-    /// + A new `Rope` with `rope` inserted at `index`
+    /// * A new `Rope` with `rope` inserted at `index`
     ///
     /// # Time Complexity
     /// O(log _n_)
     ///
     /// # Panics
-    /// + If `index` is greater than the length of this `Rope`
+    /// * If `index` is greater than the length of this `Rope`
     ///
     /// # Examples
     ///
     /// Inserting at index 0 prepends `rope` to this `Rope`:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("cd");
     /// an_rope = an_rope.with_insert_rope(0, Rope::from("ab"));
@@ -268,13 +284,15 @@ impl Rope {
     /// ```
     ///
     /// Inserting at index `len` prepends `rope` to this `Rope`:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("ab");
     /// an_rope = an_rope.with_insert_rope(an_rope.len(), Rope::from("cd"));
     /// assert_eq!(an_rope, Rope::from("abcd"));
     /// ```
     ///
-    ///Inserting at an index in the middle inserts `rope` at that index:
+    /// Inserting at an index in the middle inserts `rope` at that index:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("ad");
     /// an_rope = an_rope.with_insert_rope(1, Rope::from("bd"));
@@ -292,7 +310,7 @@ impl Rope {
     /// Insert string slice `s` into `index` in this `Rope`,
     ///
     /// # Panics
-    /// + If `index` is greater than the length of this `Rope`
+    /// * If `index` is greater than the length of this `Rope`
     ///
     /// # Time Complexity
     /// O(log _n_)
@@ -300,6 +318,7 @@ impl Rope {
     /// # Examples
     ///
     /// Inserting at index 0 prepends `s` to this `Rope`:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("cd");
     /// an_rope.insert_str(0, "ab");
@@ -307,13 +326,15 @@ impl Rope {
     /// ```
     ///
     /// Inserting at index `len` prepends `s` to this `Rope`:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("ab");
     /// an_rope.insert_str(an_rope.len(), "cd");
     /// assert_eq!(an_rope, Rope::from("abcd"));
     /// ```
     ///
-    ///Inserting at an index in the middle inserts `s` at that index:
+    /// Inserting at an index in the middle inserts `s` at that index:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("ad");
     /// an_rope = an_rope.insert_str(1, "bd");
@@ -330,10 +351,10 @@ impl Rope {
     /// Insert `s` into `index` in this `Rope`, returning a new `Rope`.
     ///
     /// # Returns
-    /// + A new `Rope` with `s` inserted at `index`
+    /// * A new `Rope` with `s` inserted at `index`
     ///
     /// # Panics
-    /// + If `index` is greater than the length of this `Rope`
+    /// *  If `index` is greater than the length of this `Rope`
     ///
     /// # Time Complexity
     /// O(log _n_)
@@ -341,6 +362,7 @@ impl Rope {
     /// # Examples
     ///
     /// Inserting at index 0 prepends `s` to this `Rope`:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("cd");
     /// an_rope = an_rope.with_insert_str(0, "ab");
@@ -348,13 +370,15 @@ impl Rope {
     /// ```
     ///
     /// Inserting at index `len` prepends `s` to this `Rope`:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("ab");
     /// an_rope = an_rope.with_insert_str(an_rope.len(), "cd");
     /// assert_eq!(an_rope, Rope::from("abcd"));
     /// ```
     ///
-    ///Inserting at an index in the middle inserts `s` at that index:
+    /// Inserting at an index in the middle inserts `s` at that index:
+    ///
     /// ```
     /// let mut an_rope = Rope::from("ad");
     /// an_rope = an_rope.with_insert_str(1, "bd");
@@ -373,6 +397,7 @@ impl Rope {
     /// Note that this is equivalent to using the `+=` operator.
     ///
     /// # Examples
+    ///
     /// ```
     /// use an_rope::Rope;
     /// let mut an_rope = Rope::from(String::from("abcd"));
@@ -394,6 +419,7 @@ impl Rope {
     /// Note that this is equivalent to using the `+` operator.
     ///
     /// # Examples
+    ///
     /// ```
     /// use an_rope::Rope;
     /// let an_rope = Rope::from("abcd");
@@ -439,6 +465,7 @@ impl Rope {
     /// Consumes `other`.
     ///
     /// # Examples
+    ///
     /// ```
     /// use an_rope::Rope;
     /// let an_rope = Rope::from("efgh");
@@ -446,6 +473,7 @@ impl Rope {
     /// assert_eq!(&an_rope, "efgh");
     /// assert_eq!(&another_rope, "abcdefgh");
     /// ```
+    ///
     /// ```
     /// use an_rope::Rope;
     /// let an_rope = Rope::from("");
@@ -453,6 +481,7 @@ impl Rope {
     /// assert_eq!(&an_rope, "");
     /// assert_eq!(&another_rope, "abcd");
     /// ```
+    ///
     /// ```
     /// use an_rope::Rope;
     /// let an_rope = Rope::from("abcd");

--- a/an-rope/src/lib.rs
+++ b/an-rope/src/lib.rs
@@ -111,6 +111,9 @@ impl Rope {
     /// # Panics
     /// + If `index` is greater than the length of this `Rope`
     ///
+    /// # Time Complexity
+    /// O(log _n_)
+    ///
     /// # Examples
     ///
     /// Inserting at index 0 prepends `char` to this `Rope`:
@@ -149,6 +152,9 @@ impl Rope {
     ///
     /// # Returns
     /// + A new `Rope` with `ch` inserted at `index`
+    ///
+    /// # Time Complexity
+    /// O(log _n_)
     ///
     /// # Panics
     /// + If `index` is greater than the length of this `Rope`
@@ -192,6 +198,9 @@ impl Rope {
     ///
     /// # Panics
     /// + If `index` is greater than the length of this `Rope`
+    ///
+    /// # Time Complexity
+    /// O(log _n_)
     ///
     /// # Examples
     ///
@@ -243,6 +252,9 @@ impl Rope {
     /// # Returns
     /// + A new `Rope` with `rope` inserted at `index`
     ///
+    /// # Time Complexity
+    /// O(log _n_)
+    ///
     /// # Panics
     /// + If `index` is greater than the length of this `Rope`
     ///
@@ -282,6 +294,9 @@ impl Rope {
     /// # Panics
     /// + If `index` is greater than the length of this `Rope`
     ///
+    /// # Time Complexity
+    /// O(log _n_)
+    ///
     /// # Examples
     ///
     /// Inserting at index 0 prepends `s` to this `Rope`:
@@ -319,6 +334,9 @@ impl Rope {
     ///
     /// # Panics
     /// + If `index` is greater than the length of this `Rope`
+    ///
+    /// # Time Complexity
+    /// O(log _n_)
     ///
     /// # Examples
     ///

--- a/an-rope/src/lib.rs
+++ b/an-rope/src/lib.rs
@@ -504,10 +504,10 @@ impl Rope {
     /// assert_eq!(cd, Rope::from(String::from("cd")));
     /// ```
     pub fn split(&mut self, index: usize) -> (Rope, Rope) {
-        // assert!(index <= self.len());
-        // let (l, r) = self.root.split(index);
-        // (Rope { root: l }, Rope { root: r })
-        unimplemented!()
+        assert!(index <= self.len());
+        let root = mem::replace(&mut self.root, Node::empty());
+        let (l, r) = root.split(index);
+        (Rope { root: l }, Rope { root: r })
     }
 
     /// Rebalances this entire `Rope`, returning a balanced `Rope`.

--- a/an-rope/src/lib.rs
+++ b/an-rope/src/lib.rs
@@ -74,7 +74,7 @@ impl Rope {
     /// let mut an_rope = Rope::<u8>::empty();
     /// assert_eq!(an_rope.len(), 0);
     /// ```
-    pub const fn new() -> Rope {
+    pub fn new() -> Rope {
         Rope { root: Node::empty() }
     }
 
@@ -219,7 +219,6 @@ impl Rope {
             } else {
                 if let &mut Branch(ref mut new_branch) = self.root.split(index) {
                     new_branch.left.as_mut()
-                              .unwrap()
                               .concat(rope.root);
                 } else {
                     unreachable!()
@@ -600,10 +599,9 @@ impl ops::Index<usize> for Node {
                , "Node::index: index {} out of bounds (length {})", i, len);
         match *self {
             Leaf(ref vec) => { &vec[i..i+1] }
-          , Branch(BranchNode { right: Some(box ref r), .. }) if len < i =>
-                &r[i - len]
-          , Branch(BranchNode { left: Some(box ref l), .. }) => &l[i]
-          , _ => unreachable!()
+          , Branch(BranchNode { box ref right, .. }) if len < i =>
+                &right[i - len]
+          , Branch(BranchNode { box ref left, .. }) => &left[i]
         }
     }
 }

--- a/an-rope/src/lib.rs
+++ b/an-rope/src/lib.rs
@@ -217,15 +217,14 @@ impl Rope {
                 // if the rope is being inserted at index len, append it
                 self.append(rope)
             } else {
-                match self.root.split(index) {
-                    &mut Branch(ref mut new_branch) => {
-                        new_branch.left.as_mut()
-                                  .concat(rope.root);
-                              }
-                  , thing =>
-                        unreachable!("Node::split didn't return a branch node? \
-                                      Got: {:?}", thing)
-                }
+                let root = mem::replace(&mut self.root, Node::empty());
+                // split the rope at the given index
+                let (left, right) = root.split(index);
+                // concatenate the left side of the rope to insert
+                let left = Node::new_branch(left, rope.root);
+                // concatenate the right side of the split to the
+                // new node and put the new node in the root position
+                self.root = Node::new_branch(left, right);
             }
             // rebalance the new rope
             self.rebalance();

--- a/an-rope/src/lib.rs
+++ b/an-rope/src/lib.rs
@@ -503,10 +503,9 @@ impl Rope {
     /// assert_eq!(ab, Rope::from(String::from("ab")));
     /// assert_eq!(cd, Rope::from(String::from("cd")));
     /// ```
-    pub fn split(&mut self, index: usize) -> (Rope, Rope) {
+    pub fn split(self, index: usize) -> (Rope, Rope) {
         assert!(index <= self.len());
-        let root = mem::replace(&mut self.root, Node::empty());
-        let (l, r) = root.split(index);
+        let (l, r) = self.root.split(index);
         (Rope { root: l }, Rope { root: r })
     }
 

--- a/an-rope/src/lib.rs
+++ b/an-rope/src/lib.rs
@@ -80,6 +80,7 @@ impl Rope {
     /// Returns the length of this Rope
     ///
     /// # Examples
+    /// An empty `Rope` should have length 0.
     /// ```
     /// use an_rope::Rope;
     /// let mut an_empty_rope = Rope::new();
@@ -90,6 +91,8 @@ impl Rope {
     /// let mut an_empty_rope = Rope::from(String::from(""));
     /// assert_eq!(an_empty_rope.len(), 0);
     /// ```
+    /// A `Rope` with text should have length equal to the number of
+    /// characters in the `Rope`.
     /// ```
     /// use an_rope::Rope;
     /// let mut an_rope = Rope::from(String::from("a string"));
@@ -355,18 +358,7 @@ impl Rope {
     /// an_rope.append(Rope::from(String::from("efgh")));
     /// assert_eq!(an_rope, Rope::from(String::from("abcdefgh")) );
     /// ```
-    /// ```
-    /// use an_rope::Rope;
-    /// let mut an_rope = Rope::from("");
-    /// an_rope.append(Rope::from("abcd"));
-    /// assert_eq!(&an_rope, "abcd");
-    /// ```
-    /// ```
-    /// use an_rope::Rope;
-    /// let mut an_rope = Rope::from("abcd");
-    /// an_rope.append(Rope::from(""));
-    /// assert_eq!(&an_rope, "abcd");
-    /// ```
+
     pub fn append(&mut self, other: Rope) {
         if other.len() > 0 {
             self.root.concat(other.root);
@@ -386,19 +378,6 @@ impl Rope {
     /// let an_rope = Rope::from("abcd");
     /// let another_rope = an_rope.with_append(Rope::from("efgh"));
     /// assert_eq!(&another_rope, "abcdefgh");
-    /// assert_eq!(&an_rope, "abcd");
-    /// ```
-    /// ```
-    /// use an_rope::Rope;
-    /// let an_rope = Rope::from("");
-    /// let another_rope = an_rope.with_append(Rope::from("abcd"));
-    /// assert_eq!(&another_rope, "abcd");
-    /// assert_eq!(&an_rope, "");
-    /// ```
-    /// ```
-    /// use an_rope::Rope;
-    /// let an_rope = Rope::from("abcd");
-    /// let an_rope = an_rope.with_append(Rope::from(""));
     /// assert_eq!(&an_rope, "abcd");
     /// ```
     pub fn with_append(&self, other: Rope) -> Rope {
@@ -427,18 +406,6 @@ impl Rope {
     /// an_rope.prepend(Rope::from(String::from("abcd")));
     /// assert_eq!(&an_rope, "abcdefgh");
     /// ```
-    /// ```
-    /// use an_rope::Rope;
-    /// let mut an_rope = Rope::from("");
-    /// an_rope.prepend(Rope::from("abcd"));
-    /// assert_eq!(&an_rope, "abcd");
-    /// ```
-    /// ```
-    /// use an_rope::Rope;
-    /// let mut an_rope = Rope::from("abcd");
-    /// an_rope.prepend(Rope::from(""));
-    /// assert_eq!(&an_rope, "abcd");
-    /// ```
     pub fn prepend(&mut self, other: Rope) {
         if other.len() > 0 {
             let old_root = mem::replace(&mut self.root, Node::empty());
@@ -459,21 +426,6 @@ impl Rope {
     /// let another_rope = an_rope.with_prepend(Rope::from("abcd"));
     /// assert_eq!(&an_rope, "efgh");
     /// assert_eq!(&another_rope, "abcdefgh");
-    /// ```
-    /// ```
-    /// use an_rope::Rope;
-    /// let an_rope = Rope::from("");
-    /// let another_rope = an_rope.with_prepend(Rope::from("abcd"));
-    /// assert_eq!(&an_rope, "");
-    /// assert_eq!(&another_rope, "abcd");
-    /// ```
-    /// ```
-    /// use an_rope::Rope;
-    /// let an_rope = Rope::from("abcd");
-    /// let another_rope = an_rope.with_prepend(Rope::from(""));
-    /// assert_eq!(&an_rope, "abcd");
-    /// assert_eq!(&another_rope, &an_rope);
-    /// assert_eq!(&another_rope, "abcd");
     /// ```
     pub fn with_prepend(&self, other: Rope) -> Rope {
         if other.len() == 0 {

--- a/an-rope/src/lib.rs
+++ b/an-rope/src/lib.rs
@@ -217,11 +217,13 @@ impl Rope {
                 // if the rope is being inserted at index len, append it
                 self.append(rope)
             } else {
-                if let &mut Branch(ref mut new_branch) = self.root.split(index) {
-                    new_branch.left.as_mut()
-                              .concat(rope.root);
-                } else {
-                    unreachable!()
+                match self.root.split(index) {
+                    &mut Branch(ref mut new_branch) =>
+                        new_branch.left.as_mut()
+                                  .concat(rope.root)
+                  , thing =>
+                        unreachable!("Node::split didn't return a branch node? \
+                                      Got: {:?}", thing)
                 }
             }
             // rebalance the new rope

--- a/an-rope/src/test.rs
+++ b/an-rope/src/test.rs
@@ -93,7 +93,7 @@ fn with_insert_rope_test_1() {
     let mut r_2 = Rope::new();
     for _ in 0..100 {
         let t: String = iter::repeat('a').take(10).collect();
-        r_2.with_insert_rope(0, Rope::from(t));
+        r_2 = r_2.with_insert_rope(0, Rope::from(t));
     }
     assert_eq!(r_1, r_2);
 }

--- a/an-rope/src/test.rs
+++ b/an-rope/src/test.rs
@@ -139,6 +139,24 @@ fn mutable_insert_char_test_1() {
 }
 
 #[test]
+fn mutable_insert_char_test_2() {
+    // this is the same as with_insert_char_test1() except mutable
+    let mut s = Rope::from("aaaaa");
+    assert_eq!(&s, "aaaaa");
+    s.insert(5, 'b');
+    assert_eq!(&s, "aaaaab");
+    s.insert(4, 'b');
+    assert_eq!(&s, "aaaabab");
+    s.insert(3, 'b');
+    assert_eq!(&s, "aaababab");
+    s.insert(2, 'b');
+    assert_eq!(&s, "aabababab");
+    s.insert(1, 'b');
+    assert_eq!(&s, "ababababab");
+
+}
+
+#[test]
 fn with_insert_char_test_1() {
     let s = Rope::from("aaaaa");
     let s_1 = s.with_insert(5, 'b');

--- a/an-rope/src/test.rs
+++ b/an-rope/src/test.rs
@@ -55,6 +55,86 @@ fn repeated_concat_right_rebalance() {
 }
 
 #[test]
+fn append_empty_rope() {
+    let mut an_rope = Rope::from("");
+    an_rope.append(Rope::from("abcd"));
+    assert_eq!(&an_rope, "abcd");
+
+    let mut an_rope = Rope::from("abcd");
+    an_rope.append(Rope::from(""));
+    assert_eq!(&an_rope, "abcd");
+}
+
+#[test]
+fn append() {
+    let mut an_rope = Rope::from(String::from("abcd"));
+    an_rope.append(Rope::from(String::from("efgh")));
+    assert_eq!(an_rope, Rope::from(String::from("abcdefgh")) );
+}
+
+#[test]
+fn with_append_empty_rope() {
+    let an_rope = Rope::from("");
+    let another_rope = an_rope.with_append(Rope::from("abcd"));
+    assert_eq!(&another_rope, "abcd");
+    assert_eq!(&an_rope, "");
+
+    let an_rope = Rope::from("abcd");
+    let an_rope = an_rope.with_append(Rope::from(""));
+    assert_eq!(&an_rope, "abcd");
+}
+
+#[test]
+fn with_append() {
+    let an_rope = Rope::from("abcd");
+    let another_rope = an_rope.with_append(Rope::from("efgh"));
+    assert_eq!(&another_rope, "abcdefgh");
+    assert_eq!(&an_rope, "abcd");
+}
+
+#[test]
+fn prepend_empty_rope() {
+    let mut an_rope = Rope::from("");
+    an_rope.prepend(Rope::from("abcd"));
+    assert_eq!(&an_rope, "abcd");
+
+
+    let mut an_rope = Rope::from("abcd");
+    an_rope.prepend(Rope::from(""));
+    assert_eq!(&an_rope, "abcd");
+}
+
+
+#[test]
+fn with_prepend_empty_rope() {
+    let an_rope = Rope::from("");
+    let another_rope = an_rope.with_prepend(Rope::from("abcd"));
+    assert_eq!(&an_rope, "");
+    assert_eq!(&another_rope, "abcd");
+
+    let an_rope = Rope::from("abcd");
+    let another_rope = an_rope.with_prepend(Rope::from(""));
+    assert_eq!(&an_rope, "abcd");
+    assert_eq!(&another_rope, &an_rope);
+    assert_eq!(&another_rope, "abcd");
+}
+
+#[test]
+fn with_prepend() {
+    let an_rope = Rope::from("efgh");
+    let another_rope = an_rope.with_prepend(Rope::from("abcd"));
+    assert_eq!(&an_rope, "efgh");
+    assert_eq!(&another_rope, "abcdefgh");
+}
+
+#[test]
+fn prepend() {
+    let mut an_rope = Rope::from(String::from("efgh"));
+    an_rope.prepend(Rope::from(String::from("abcd")));
+    assert_eq!(&an_rope, "abcdefgh");
+}
+
+#[test]
 fn merge_rebalance_test() {
     let s = "Lorem ipsum dolor sit amet, consectetur adipiscing eli\
              t, sed do eiusmod tempor incididunt ut labore et dolor\


### PR DESCRIPTION
This PR rewrites Rope to use `Leaf("")` rather than `Option` to represent empty nodes (see #16). It also fixes some additional issues in the `Rope::*_insert_*` method family, as well as bugs in iteration in the incorrect order.

Closes #16 
Closes #7